### PR TITLE
Refactor handle_response function to handle FileUrl response

### DIFF
--- a/lib/api2pdf.ex
+++ b/lib/api2pdf.ex
@@ -42,6 +42,9 @@ defmodule Api2pdf do
   defp handle_response(%{body: %{"UserBalance" => _} = body}),
     do: {:ok, BalanceCheckSuccessResponse.from_body(body)}
 
+  defp handle_response(%{body: %{"FileUrl" => file_url} = body}) when is_binary(file_url),
+    do: {:ok, ApiSuccessResponse.from_body(body)}
+
   defp handle_response(%{body: %{"Error" => nil} = body}),
     do: {:ok, ApiSuccessResponse.from_body(body)}
 


### PR DESCRIPTION
This refactor of the handle_response function ensures that the function can handle cases where the "Error" field is absent in the API response. Previously, the function assumed "Error" would always be present, potentially causing issues when it was missing.

With this update:

The function now prioritizes responses with "UserBalance" or "FileUrl" fields.
It handles the "FileUrl" case only when the value is a string, treating these as successful responses.